### PR TITLE
Atualiza README com seção de perfil atual e projetos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,29 @@ Sou o Carlos Eduardo (Cadu), engenheiro de dados na GFT, com foco no desenvolvim
 
 👨‍💻 Além dos dados, sou movido por uma curiosidade constante por engenharia de software como um todo. Tenho estudado **Terraform** para provisionamento de infraestrutura como código e investigado boas práticas para desenvolver aplicações escaláveis na **AWS** e no **Google Cloud**.
 
-👾 Nos projetos pessoais, costumo aplicar esse interesse técnico em temas que me divertem:
-
-- Análise de dados do *League of Legends* via API da Riot  
-- Estudos sobre mercado e performance no futebol com dados do StatsBomb  
-- Soluções de automação para pequenos negócios, cuidando de estoque, finanças e atendimento ao cliente
-
 🚀 Tenho explorado stacks como **Django/DRF**, **FastAPI**, **DBT**, **Supabase**, **Firebase** e **Apps Script** — ferramentas que venho estudando com atenção para ampliar meu repertório técnico. Também gosto de experimentar abordagens criativas, como o uso de armazenamento local e integrações de baixo custo, quando o projeto pede.
 
 ⚽ Fora do trabalho, sou **Botafoguense**, pratico **jiu-jitsu** e tenho a **música** como parte essencial do meu dia a dia. Gosto de buscar conexões entre tecnologia e o que realmente movimenta a minha vida.
 
-# Top linguagens mais utilizadas
+# Perfil Atual
 
-Obs.: Precisei criar este novo cantinho no GitHub porque acabei perdendo as recovery keys da minha conta antiga. Se quiser ver o que eu já vinha construindo, dá uma olhada no meu perfil anterior [aqui](https://github.com/cadusds).
-## Perfil atual:
-![Top Linguagens atual](https://github-readme-stats.vercel.app/api/top-langs/?username=cadusds2&layout=compact&theme=tokyonight)
-## Perfil antigo:
-![Top Linguagens perfil antigo](https://github-readme-stats.vercel.app/api/top-langs/?username=cadusds&layout=compact&theme=tokyonight)
-
+![Seguidores](https://img.shields.io/github/followers/cadusds2?style=social) ![Estrelas](https://img.shields.io/github/stars/cadusds2?style=social)
 
 ![Cadu's GitHub Stats](https://github-readme-stats.vercel.app/api?username=cadusds2&show_icons=true&theme=tokyonight)
 ![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=cadusds2&layout=compact&theme=tokyonight)
 ![GitHub Streak](https://streak-stats.demolab.com?user=cadusds2&theme=tokyonight)
+
+### Projetos Ativos
+
+- 🕹️ **LoL Insights** — *Python, API da Riot*  
+  Análises de partidas para entender padrões de jogo e desempenho.
+- ⚽ **Futebol Analytics** — *Python, StatsBomb*  
+  Exploração de dados para estudar mercado e performance no futebol.
+- 🤖 **Automação para Pequenos Negócios** — *Supabase, Firebase, Apps Script*  
+  Ferramentas de controle de estoque, finanças e atendimento para pequenos empreendedores.
+
+## Perfil Antigo
+
+Obs.: Precisei criar este novo cantinho no GitHub porque acabei perdendo as recovery keys da minha conta antiga. Se quiser ver o que eu já vinha construindo, dá uma olhada no meu perfil anterior [aqui](https://github.com/cadusds).
+
+![Top Linguagens perfil antigo](https://github-readme-stats.vercel.app/api/top-langs/?username=cadusds&layout=compact&theme=tokyonight)


### PR DESCRIPTION
## Resumo
- adiciona seção **Perfil Atual** com badges e estatísticas da conta
- lista projetos ativos com tecnologias e objetivos

## Testes
- `pytest`
- `pre-commit run --files README.md` *(falhou: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3b7445c88332b04fadd012c3040e